### PR TITLE
Fix local variables allocation

### DIFF
--- a/compiler/codegen_test.go
+++ b/compiler/codegen_test.go
@@ -326,23 +326,21 @@ fun_main:
 intc 1
 store 0
 load 0
-store 3
 intc 2
-store 4
 callsub fun_sum
 store 1
 intc 3
 store 2
 load 2
-store 3
 intc 1
-store 4
 callsub fun_sum
 store 3
 intc 1
 return
 end_main:
 fun_sum:
+store 4
+store 3
 load 3
 load 4
 +
@@ -351,8 +349,8 @@ end_sum:
 `
 	CompareTEAL(a, expected, actual)
 	lines := strings.Split(actual, "\n")
-	a.Equal(lines[8], lines[16])               // callsub func_sum_*
-	a.True(lines[21][len(lines[21])-1] == ':') // func_sum_*:
+	a.Equal(lines[7], lines[13])               // callsub func_sum_*
+	a.True(lines[18][len(lines[18])-1] == ':') // func_sum_*:
 }
 
 func TestCodegenGeneric(t *testing.T) {

--- a/test/func_test.go
+++ b/test/func_test.go
@@ -33,3 +33,96 @@ function logic() {
 `
 	performTest(t, source)
 }
+
+func TestFuncSlotsAlloc1(t *testing.T) {
+	source := `
+let g = ""
+
+function getch(digit) {
+	return itob(digit + 48)
+}
+
+function mod10(nn) {
+	g = getch(nn / 10)
+	return nn % 10
+}
+
+function logic() {
+	let a = mod10(74)
+	assert(a == 4)
+	let b = mod10(a+1)
+	assert(b == 5)
+	// assert(g != "")
+	return 1
+}
+`
+	performTest(t, source)
+}
+
+func TestFuncSlotsAlloc2(t *testing.T) {
+	source := `
+let g = ""
+
+function sum(x, y) {
+	return x + y
+}
+
+function mod10(nn) {
+	let x = 10
+	g = itob(sum(nn, nn / x))
+	return nn % 10
+}
+
+function logic() {
+	let a = mod10(74)
+	assert(a == 4)
+	assert(g != "")
+	let x = 1
+	let y = 2
+	let c = sum(x, y)
+	assert(c == 3)
+	return 1
+}
+`
+	performTest(t, source)
+}
+
+func TestFuncSlotsAlloc3(t *testing.T) {
+	source := `
+let g = ""
+
+function sum(x, y) {
+	return x + y
+}
+
+function mod10(nn) {
+	let x = 10
+	g = itob(sum(nn, nn / x))
+	return nn % 10
+}
+
+// non-commutative op to ensure args order
+function modsum(a, b) {
+	let r = a % b
+	let p = r + sum(a, b)
+	return p
+}
+
+function logic() {
+	let a = mod10(74)
+	assert(a == 4)
+	assert(g != "")
+	let x = 1
+	let y = 2
+	let c = sum(x, y)
+	assert(c == 3)
+	let z = modsum(x, y)
+	assert(z == 4)
+	let yy = 5
+	let zz = modsum(z, yy)
+	assert(zz == 13)
+	return 1
+}
+`
+	performTest(t, source)
+}


### PR DESCRIPTION
When function is called it is lazily parsed in order to
deduct arguments types. It also creates a nested scope (context).
Scopes have start and last addresses for variables allocations, and
the allocation is based on parent's scope last used address.

Because the child scope starts growing while parent was not completed
this can cause problems with when the same function is called again later
and the parent allocated some vars between invocations.

In order to fix this scopes gets remapped on each function call
up to the leaves by updating.
Additionally, regular functions now pass arguments via stack.