### PR TITLE
Add a new make algorand-install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,30 @@ default: build
 all: go test grammar-java
 build: go
 
-algorand-link:
-	SYM_DIR_LOC=$$(go env GOPATH)/pkg/mod/$$(echo $$(grep -F 'github.com/algorand/go-algorand' go.mod | sed 's/ /@/' | cut -d " " -f1 )) ; \
-	SYM_DIR_TARG=$$(go env GOPATH)/src/github.com/algorand/go-algorand; \
-	[ ! -d "$$SYM_DIR_TARG" ] && echo "error: target directory not found ($$SYM_DIR_TARG)" && exit 1; \
-	mkdir -p "$$(dirname "$$SYM_DIR_LOC")"; \
-	[ -e "$$SYM_DIR_LOC" ] && mv "$$SYM_DIR_LOC" "$${SYM_DIR_LOC}__BACKUP__"; \
-	echo "targ=$$SYM_DIR_TARG" "linkloc=$$SYM_DIR_LOC"; \
-	ln -s "$$SYM_DIR_TARG" "$$SYM_DIR_LOC"
+GO_ALGORAND := github.com/algorand/go-algorand
+
+algorand-install:
+	VERSION=$$(grep -F '$(GO_ALGORAND)' go.mod | cut -d " " -f2) && \
+	REVISION=$$(grep -F '$(GO_ALGORAND)' go.mod | cut -d " " -f2 | cut -d "-" -f3) && \
+	MOD_LOC=$$(go env GOPATH)/pkg/mod/$(GO_ALGORAND)@$$VERSION && \
+	[ ! -d "$$MOD_LOC" ] && go get -u github.com/algorand/go-algorand@$$REVISION || true
+
+	VERSION=$$(grep -F '$(GO_ALGORAND)' go.mod | cut -d " " -f2) && \
+	REVISION=$$(grep -F '$(GO_ALGORAND)' go.mod | cut -d " " -f2 | cut -d "-" -f3) && \
+	MOD_LOC=$$(go env GOPATH)/pkg/mod/$(GO_ALGORAND)@$$VERSION && \
+	chmod -R 755 $$MOD_LOC && \
+	cd $$MOD_LOC && \
+	mkdir -p scripts/buildtools && \
+	curl -o scripts/buildtools/install_buildtools.sh https://raw.githubusercontent.com/algorand/go-algorand/$$REVISION/scripts/buildtools/install_buildtools.sh && \
+	curl -o scripts/buildtools/go.mod https://raw.githubusercontent.com/algorand/go-algorand/$$REVISION/scripts/buildtools/go.mod && \
+	chmod +x scripts/buildtools/install_buildtools.sh && \
+	./scripts/configure_dev.sh && ./scripts/buildtools/install_buildtools.sh && make build && \
+	cd -
 
 ANTLR4_VER := 4.9.3
 ANTLR4_JAR := /usr/local/lib/antlr-$(ANTLR4_VER)-complete.jar
 
-setup-antlr:
+antlr-install:
 	sudo curl -o $(ANTLR4_JAR) https://www.antlr.org/download/antlr-$(ANTLR4_VER)-complete.jar
 	export CLASSPATH="$(ANTLR4_JAR):$$CLASSPATH"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tealang
 
-High-level language for Algorand Smart Contracts at Layer-1 and its low-level **TEAL v2** language.
+High-level language for Algorand Smart Contracts at Layer-1 and its low-level **TEAL v4** language.
 The goal is to abstract the stack-based **TEAL** VM and provide imperative Go/JS/Python-like syntax.
 
 ## Language Features
@@ -19,14 +19,18 @@ let a = (1 + 2) / 3
 let b = ~a
 ```
 
-* Inlined functions
+* Functions
 ```
-function sample(a) {
+inline function sample1(a) {
     return a - 1
 }
 
+inline function sample2(a) {
+    return a + 1
+}
+
 function logic() {
-    return sample(2)
+    return sample1(2) + sample2(3)
 }
 ```
 
@@ -97,37 +101,18 @@ Checkout [syntax highlighter](https://github.com/pzbitskiy/tealang-syntax-highli
 ### Prerequisites
 
 1. Set up **ANTLR4** as explained in [the documentation](https://www.antlr.org/)
-   Or run `make setup-antlr`
+   Or run `make antlr-install`
 2. Install runtime for Go
     ```sh
     go get -u github.com/antlr/antlr4/runtime/Go/antlr
     ```
 3. Install and setup **go-algorand**. Read [Algorand README](https://github.com/algorand/go-algorand/blob/master/README.md) if needed.
     ```sh
-    GO111MODULE=off go get -u github.com/algorand/go-algorand
-    pushd $(go env GOPATH)/src/github.com/algorand/go-algorand
-    make build
-    popd
+    make algorand-install
     ```
-4. If you see the error
-   ```
-   ../../go/src/github.com/algorand/go-algorand/logging/telemetry.go:78:32: multiple-value uuid.NewV4() in single-value context
-   ```
-   then
-   ```sh
-   pushd $(go env GOPATH)/src/github.com/satori/go.uuid
-   git checkout v1.2.0
-   popd
-   ```
-
-5. Link the pkg directory to the src that you just created.
-   ```sh
-   make algorand-link
-   ```
-
 ### Build and test
 ```sh
-GO111MODULE=on make
+make
 ```
 
 ### Build and run Java AST visualizer

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/pzbitskiy/tealang
 go 1.14
 
 require (
-	github.com/algorand/go-algorand v0.0.0-20210628132655-fbae4283d1a5
-	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210521184019-c5ad59b459ec
+	github.com/algorand/go-algorand v0.0.0-20210927142222-b619b940e561
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220314183648-97c793e446ba
 	github.com/spf13/cobra v0.0.3
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/algorand/go-algorand v0.0.0-20210628132655-fbae4283d1a5 h1:FTMBFF0JJjJu8KdObXAPL6eYuDtCUDCb99Wu1lN3XfQ=
-github.com/algorand/go-algorand v0.0.0-20210628132655-fbae4283d1a5/go.mod h1:JhuQba5/ohWDsEJXDbhE3ReSg4/hxI8PUfNm7R7yfFo=
+github.com/algorand/go-algorand v0.0.0-20210927142222-b619b940e561 h1:R1gawMVC75jdBb6E5hsIl8IWboIwYSIGZUSZ+btfc5Q=
+github.com/algorand/go-algorand v0.0.0-20210927142222-b619b940e561/go.mod h1:6WtuV2NdkYRy7obVU6XtXkGVsEDxy0yDxqwjXljHbyo=
 github.com/algorand/go-codec v1.1.2 h1:QWS9YC3EEWBpJq5AqFPELcCJ2QPpTIg9aqR2K/sRDq4=
 github.com/algorand/go-codec v1.1.2/go.mod h1:A3YI4V24jUUnU1eNekNmx2fLi60FvlNssqOiUsyfNM8=
 github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d h1:W9MgGUodEl4Y4+CxeEr+T3fZ26kOcWA4yfqhjbFxxmI=
@@ -7,12 +7,12 @@ github.com/algorand/go-codec/codec v0.0.0-20190507210007-269d70b6135d/go.mod h1:
 github.com/algorand/go-deadlock v0.2.1 h1:TQPQwWAB133bS5uwHpmrgH5hCMyZK5hnUW26aqWMvq4=
 github.com/algorand/go-deadlock v0.2.1/go.mod h1:HgdF2cwtBIBCL7qmUaozuG/UIZFR6PLpSMR58pvWiXE=
 github.com/algorand/graphtrace v0.0.0-20201117160756-e524ed1a6f64/go.mod h1:qFtQmC+kmsfnLfS9j3xgKtzsWyozemL5ek1R4dWZa5c=
-github.com/algorand/msgp v1.1.47 h1:xeU6G/Mb1iudJe4L5X38YrOY+VHhvHQDZXxyXYHTzOw=
-github.com/algorand/msgp v1.1.47/go.mod h1:LtOntbYiCHj/Sl/Sqxtf8CZOrDt2a8Dv3tLaS6mcnUE=
+github.com/algorand/msgp v1.1.48 h1:5P+gVmTnk0m37r+rA3ZsFZW219ZqmCLulW5f8Z+3nx8=
+github.com/algorand/msgp v1.1.48/go.mod h1:LtOntbYiCHj/Sl/Sqxtf8CZOrDt2a8Dv3tLaS6mcnUE=
 github.com/algorand/oapi-codegen v1.3.5-algorand5/go.mod h1:/k0Ywn0lnt92uBMyE+yiRf/Wo3/chxHHsAfenD09EbY=
 github.com/algorand/websocket v1.4.2/go.mod h1:0nFSn+xppw/GZS9hgWPS3b8/4FcA3Pj7XQxm+wqHGx8=
-github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210521184019-c5ad59b459ec h1:EEyRvzmpEUZ+I8WmD5cw/vY8EqhambkOqy5iFr0908A=
-github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210521184019-c5ad59b459ec/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220314183648-97c793e446ba h1:GzYOm7fQbUZvAWPPBKxGqCmzTXJ2AYuWz4187HVxjno=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220314183648-97c793e446ba/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/aws/aws-sdk-go v1.16.5 h1:NVxzZXIuwX828VcJrpNxxWjur1tlOBISdMdDdHIKHcc=
 github.com/aws/aws-sdk-go v1.16.5/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/cpuguy83/go-md2man v1.0.8/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dYQLjr7cDsKY=
@@ -52,7 +52,7 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/karalabe/hid v0.0.0-20181128192157-d815e0c1a2e2/go.mod h1:YvbcH+3Wo6XPs9nkgTY3u19KXLauXW+J5nB7hEHuX0A=
+github.com/karalabe/hid v1.0.0/go.mod h1:Vr51f8rUOLYrfrWDFlV12GGQgM5AT8sVh+2fY4MPeu8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-//go:generate sh ./bundle_stdlib_files.sh
+//go:generate bash ./bundle_stdlib_files.sh
 
 // StdLibName constant name
 const StdLibName string = "stdlib"


### PR DESCRIPTION
Update go-algorand to v3.0.1-stable
Sequence:
1. find the commit hash matching to the tag: b619b940e561
2. set to to go.mod
3. run `go get github.com/algorand/go-algorand@b619b940e561`
it will complain about the timestamp. Update the timestamp.
4. run `make algorand-install` to build and update dependencies